### PR TITLE
Adding spark.hadoop.fs.azure properties needed for NativeAzureFileSystem to work correctly in spark context.

### DIFF
--- a/python/feast_spark/pyspark/historical_feature_retrieval_job.py
+++ b/python/feast_spark/pyspark/historical_feature_retrieval_job.py
@@ -640,7 +640,7 @@ def _read_and_verify_entity_df_from_source(
 
 
 def _type_casting_allowed(feature_type: str, source_col_type):
-    allowed_casting_for_source_col = {"double": ["float"]}
+    allowed_casting_for_source_col = {"double": ["float"], "bigint": ["int"]}
 
     if feature_type == source_col_type:
         return True

--- a/python/feast_spark/pyspark/launchers/synapse/synapse_utils.py
+++ b/python/feast_spark/pyspark/launchers/synapse/synapse_utils.py
@@ -148,6 +148,12 @@ class SynapseJobRunner(object):
         executor_cores = EXECUTOR_SIZE[self._executor_size]['Cores']
         executor_memory = EXECUTOR_SIZE[self._executor_size]['Memory']
 
+        # This is needed to correctly set the spark properties needed by org.apache.hadoop.fs.azure.NativeAzureFileSystem
+        # Please see: https://github.com/Azure/feast-azure/issues/41
+        if "FEAST_AZURE_BLOB_ACCOUNT_NAME" in os.environ and "FEAST_AZURE_BLOB_ACCOUNT_ACCESS_KEY" in os.environ:
+          blob_configuration = {f'spark.hadoop.fs.azure.account.key.{os.environ["FEAST_AZURE_BLOB_ACCOUNT_NAME"]}.blob.core.windows.net': os.environ["FEAST_AZURE_BLOB_ACCOUNT_ACCESS_KEY"]}
+          configuration = blob_configuration if configuration is None else configuration.update(blob_configuration)
+
         # SDK source code is here: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/synapse/azure-synapse
         # Exact code is here: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/synapse/azure-synapse-spark/azure/synapse/spark/operations/_spark_batch_operations.py#L114
         # Adding spaces between brackets. This is to workaround this known YARN issue (when running Spark on YARN):

--- a/python/feast_spark/pyspark/launchers/synapse/synapse_utils.py
+++ b/python/feast_spark/pyspark/launchers/synapse/synapse_utils.py
@@ -152,11 +152,17 @@ class SynapseJobRunner(object):
         # Please see: https://github.com/Azure/feast-azure/issues/41
         if "FEAST_AZURE_BLOB_ACCOUNT_NAME" in os.environ and "FEAST_AZURE_BLOB_ACCOUNT_ACCESS_KEY" in os.environ:
             blob_configuration = {f'spark.hadoop.fs.azure.account.key.{os.environ["FEAST_AZURE_BLOB_ACCOUNT_NAME"]}.blob.core.windows.net': os.environ["FEAST_AZURE_BLOB_ACCOUNT_ACCESS_KEY"]}
-            configuration = blob_configuration if configuration is None else configuration.update(blob_configuration)
-        
+            if configuration is None:
+                configuration = blob_configuration
+            else:
+                configuration.update(blob_configuration)
+
         if "FEAST_S3A_ACCESS_KEY" in os.environ and "FEAST_S3A_SECRET_KEY" in os.environ and "FEAST_S3A_ENDPOINT" in os.environ:
             s3_configuration = { "spark.hadoop.fs.s3a.endpoint" : os.environ["FEAST_S3A_ENDPOINT"], "spark.hadoop.fs.s3a.access.key" : os.environ["FEAST_S3A_ACCESS_KEY"], "spark.hadoop.fs.s3a.secret.key" : os.environ["FEAST_S3A_SECRET_KEY"]}
-            configuration = s3_configuration if configuration is None else configuration.update(s3_configuration)
+            if configuration is None:
+                configuration = s3_configuration
+            else:
+                configuration.update(s3_configuration)
 
         # SDK source code is here: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/synapse/azure-synapse
         # Exact code is here: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/synapse/azure-synapse-spark/azure/synapse/spark/operations/_spark_batch_operations.py#L114

--- a/python/feast_spark/pyspark/launchers/synapse/synapse_utils.py
+++ b/python/feast_spark/pyspark/launchers/synapse/synapse_utils.py
@@ -151,12 +151,13 @@ class SynapseJobRunner(object):
         # This is needed to correctly set the spark properties needed by org.apache.hadoop.fs.azure.NativeAzureFileSystem
         # Please see: https://github.com/Azure/feast-azure/issues/41
         if "FEAST_AZURE_BLOB_ACCOUNT_NAME" in os.environ and "FEAST_AZURE_BLOB_ACCOUNT_ACCESS_KEY" in os.environ:
-          blob_configuration = {f'spark.hadoop.fs.azure.account.key.{os.environ["FEAST_AZURE_BLOB_ACCOUNT_NAME"]}.blob.core.windows.net': os.environ["FEAST_AZURE_BLOB_ACCOUNT_ACCESS_KEY"]}
-          configuration = blob_configuration if configuration is None else configuration.update(blob_configuration)
+            blob_configuration = {f'spark.hadoop.fs.azure.account.key.{os.environ["FEAST_AZURE_BLOB_ACCOUNT_NAME"]}.blob.core.windows.net': os.environ["FEAST_AZURE_BLOB_ACCOUNT_ACCESS_KEY"]}
+            configuration = blob_configuration if configuration is None else configuration.update(blob_configuration)
         
         if "FEAST_S3A_ACCESS_KEY" in os.environ and "FEAST_S3A_SECRET_KEY" in os.environ and "FEAST_S3A_ENDPOINT" in os.environ:
             s3_configuration = { "spark.hadoop.fs.s3a.endpoint" : os.environ["FEAST_S3A_ENDPOINT"], "spark.hadoop.fs.s3a.access.key" : os.environ["FEAST_S3A_ACCESS_KEY"], "spark.hadoop.fs.s3a.secret.key" : os.environ["FEAST_S3A_SECRET_KEY"]}
-        
+            configuration = s3_configuration if configuration is None else configuration.update(s3_configuration)
+
         # SDK source code is here: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/synapse/azure-synapse
         # Exact code is here: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/synapse/azure-synapse-spark/azure/synapse/spark/operations/_spark_batch_operations.py#L114
         # Adding spaces between brackets. This is to workaround this known YARN issue (when running Spark on YARN):

--- a/python/feast_spark/pyspark/launchers/synapse/synapse_utils.py
+++ b/python/feast_spark/pyspark/launchers/synapse/synapse_utils.py
@@ -147,7 +147,13 @@ class SynapseJobRunner(object):
         driver_memory = EXECUTOR_SIZE[self._executor_size]['Memory']
         executor_cores = EXECUTOR_SIZE[self._executor_size]['Cores']
         executor_memory = EXECUTOR_SIZE[self._executor_size]['Memory']
-
+        
+        # This is needed to correctly set the spark properties needed by org.apache.hadoop.fs.azure.NativeAzureFileSystem
+        # Please see: https://github.com/Azure/feast-azure/issues/41
+        if "FEAST_AZURE_BLOB_ACCOUNT_NAME" in os.environ and "FEAST_AZURE_BLOB_ACCOUNT_ACCESS_KEY" in os.environ:
+          blob_configuration = {f'spark.hadoop.fs.azure.account.key.{os.environ["FEAST_AZURE_BLOB_ACCOUNT_NAME"]}.blob.core.windows.net': os.environ["FEAST_AZURE_BLOB_ACCOUNT_ACCESS_KEY"]}
+          configuration = blob_configuration if configuration is None else configuration.update(blob_configuration)
+        
         # SDK source code is here: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/synapse/azure-synapse
         # Exact code is here: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/synapse/azure-synapse-spark/azure/synapse/spark/operations/_spark_batch_operations.py#L114
         # Adding spaces between brackets. This is to workaround this known YARN issue (when running Spark on YARN):

--- a/python/feast_spark/pyspark/launchers/synapse/synapse_utils.py
+++ b/python/feast_spark/pyspark/launchers/synapse/synapse_utils.py
@@ -154,6 +154,9 @@ class SynapseJobRunner(object):
           blob_configuration = {f'spark.hadoop.fs.azure.account.key.{os.environ["FEAST_AZURE_BLOB_ACCOUNT_NAME"]}.blob.core.windows.net': os.environ["FEAST_AZURE_BLOB_ACCOUNT_ACCESS_KEY"]}
           configuration = blob_configuration if configuration is None else configuration.update(blob_configuration)
         
+        if "FEAST_S3A_ACCESS_KEY" in os.environ and "FEAST_S3A_SECRET_KEY" in os.environ and "FEAST_S3A_ENDPOINT" in os.environ:
+            s3_configuration = { "spark.hadoop.fs.s3a.endpoint" : os.environ["FEAST_S3A_ENDPOINT"], "spark.hadoop.fs.s3a.access.key" : os.environ["FEAST_S3A_ACCESS_KEY"], "spark.hadoop.fs.s3a.secret.key" : os.environ["FEAST_S3A_SECRET_KEY"]}
+        
         # SDK source code is here: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/synapse/azure-synapse
         # Exact code is here: https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/synapse/azure-synapse-spark/azure/synapse/spark/operations/_spark_batch_operations.py#L114
         # Adding spaces between brackets. This is to workaround this known YARN issue (when running Spark on YARN):


### PR DESCRIPTION
**What this PR does / why we need it**:
Setting spark hadoop properties in spark job (specifically for `historical_feature_retrieval` but might be applicable in other scenarios).

**Which issue(s) this PR fixes**:
https://github.com/Azure/feast-azure/issues/41

**Does this PR introduce a user-facing change?**:
Yes